### PR TITLE
Add event bus to TCP server

### DIFF
--- a/src/internal/server/server.go
+++ b/src/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"airshift/openmos/internal/config"
+	"airshift/openmos/internal/events"
 	"airshift/openmos/internal/service"
 	"airshift/openmos/pkg/logger"
 )
@@ -19,12 +20,13 @@ type TCPServer struct {
 	clientsMu  sync.RWMutex
 	service    *service.MOSService
 	config     *config.Config
+	eventBus   *events.EventBus
 	wg         sync.WaitGroup
 	shutdownCh chan struct{}
 }
 
 // NewTCPServer creates a new TCP server instance
-func NewTCPServer(cfg *config.Config, mosService *service.MOSService) (*TCPServer, error) {
+func NewTCPServer(cfg *config.Config, mosService *service.MOSService, eventBus *events.EventBus) (*TCPServer, error) {
 	address := cfg.GetServerAddress()
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
@@ -36,6 +38,7 @@ func NewTCPServer(cfg *config.Config, mosService *service.MOSService) (*TCPServe
 		clients:    make(map[string]*ClientConnection),
 		service:    mosService,
 		config:     cfg,
+		eventBus:   eventBus,
 		shutdownCh: make(chan struct{}),
 	}
 

--- a/src/internal/service/story.go
+++ b/src/internal/service/story.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"airshift/openmos/internal/events"
 	"airshift/openmos/internal/model"
 	"airshift/openmos/internal/xml"
 	"airshift/openmos/pkg/logger"
@@ -93,6 +94,15 @@ func (s *MOSService) createNewStory(ctx context.Context, storySend xml.ROStorySe
 		return fmt.Errorf("failed to create story: %w", err)
 	}
 
+	// Publish event after successful creation
+	if s.eventBus != nil {
+		s.eventBus.Publish(events.Event{
+			Type:    events.StoryModified,
+			Payload: story.ID,
+			Source:  "mos_service",
+		})
+	}
+
 	logger.Infof("Created new story %s in running order %s", story.ID, ro.ID)
 	return nil
 }
@@ -120,6 +130,15 @@ func (s *MOSService) updateStory(ctx context.Context, storySend xml.ROStorySend)
 	err = s.storyRepo.Update(ctx, story)
 	if err != nil {
 		return fmt.Errorf("failed to update story: %w", err)
+	}
+
+	// Publish event after successful update
+	if s.eventBus != nil {
+		s.eventBus.Publish(events.Event{
+			Type:    events.StoryModified,
+			Payload: story.ID,
+			Source:  "mos_service",
+		})
 	}
 
 	logger.Infof("Updated story %s in running order %s", story.ID, story.RunningOrderID)

--- a/src/main.go
+++ b/src/main.go
@@ -11,6 +11,7 @@ import (
 
 	"airshift/openmos/internal/config"
 	"airshift/openmos/internal/db"
+	"airshift/openmos/internal/events"
 	"airshift/openmos/internal/repository"
 	"airshift/openmos/internal/server"
 	"airshift/openmos/internal/service"
@@ -123,12 +124,15 @@ func main() {
 	itemRepo := repository.NewMongoItemRepository(database)
 	objectRepo := repository.NewMongoObjectRepository(database)
 
+	// Create event bus for pub-sub messaging
+	eventBus := events.NewEventBus()
+
 	// Create service
-	mosService := service.NewMOSService(runningOrderRepo, storyRepo, itemRepo, objectRepo)
+	mosService := service.NewMOSService(runningOrderRepo, storyRepo, itemRepo, objectRepo, eventBus)
 
 	// Create and start TCP server
 	log.Info("Starting TCP server...")
-	tcpServer, err := server.NewTCPServer(cfg, mosService)
+	tcpServer, err := server.NewTCPServer(cfg, mosService, eventBus)
 	if err != nil {
 		log.CaptureException(err, map[string]string{
 			"component": "server",


### PR DESCRIPTION
- Add eventBus field to TCPServer and pass through NewTCPServer
- Add eventBus field to MOSService and pass through NewMOSService
- Publish RunningOrderUpdated events after ProcessRunningOrderInfo
- Publish StoryModified events after story create/update operations
- Subscribe clients to RunningOrderUpdated events in ClientConnection.Start
- Add handleRunningOrderUpdate to push running order changes to clients
- Update main.go to create EventBus and wire it through service and server